### PR TITLE
Card logic styling v1

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -3,17 +3,14 @@
   "name": "Create React App Sample",
   "icons": [
     {
-      "src": "favicon.ico",
       "sizes": "64x64 32x32 24x24 16x16",
       "type": "image/x-icon"
     },
     {
-      "src": "logo192.png",
       "type": "image/png",
       "sizes": "192x192"
     },
     {
-      "src": "logo512.png",
       "type": "image/png",
       "sizes": "512x512"
     }

--- a/src/components/DreamCard.js
+++ b/src/components/DreamCard.js
@@ -1,15 +1,8 @@
 import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import {
-  Button,
-  Card,
-  CardTitle,
-  Container,
-  Row,
-  Col,
-  Collapse,
-  CardBody,
-  CardText
+  Button, Card, CardTitle, Container, Row,
+  Col, Collapse, CardBody, CardText
 } from 'reactstrap';
 import PropTypes from 'prop-types';
 import { deleteDream } from '../helpers/data/DreamData';
@@ -22,8 +15,8 @@ const DreamCard = ({
   setDreams
 }) => {
   const [editing, setEditing] = useState(false);
-  const history = useHistory();
   const [isOpen, setIsOpen] = useState(false);
+  const history = useHistory();
 
   const toggle = () => setIsOpen(!isOpen);
 
@@ -57,8 +50,20 @@ const DreamCard = ({
               </Row>
               <Row><div>_______________________________________________</div></Row>
               <Row><div className="date">november 11, 2011</div></Row>
-              <Row><div></div></Row>
               <div>
+                <Button color="transparent" style={{ marginBottom: '1rem' }} onClick={() => handleClick('edit')}>
+                  {editing ? 'Done' : 'Edit'}
+                </Button>
+                {
+                  editing && <DreamForm
+                    formTitle='Edit Dream'
+                    setDreams={setDreams}
+                    firebaseKey={firebaseKey}
+                    name={name}
+                    entry={entry}
+                  />
+                }
+                           </div>
                 <Button color="transparent" onClick={toggle} style={{ marginBottom: '1rem' }}>
                   <i className="material-icons" id="expand-arrow"> keyboard_arrow_down </i></Button>
                 <Collapse isOpen={isOpen}>
@@ -66,25 +71,12 @@ const DreamCard = ({
                     <CardBody>
                       <CardText>{entry}</CardText>
                       <div className="card-link-wrapper">
-                      <Button color="transparent" onClick={() => handleClick('view')}>View</Button>
-                      <Button color="transparent" onClick={() => handleClick('delete')}>Delete</Button>
-                      <Button color="transparent" onClick={() => handleClick('edit')}>
-                        {editing ? 'Close Form' : 'Edit'}
-                      </Button>
-                      {
-                        editing && <DreamForm
-                          formTitle='Edit Dream'
-                          setDreams={setDreams}
-                          firebaseKey={firebaseKey}
-                          name={name}
-                          entry={entry}
-                        />
-                      }
+                        <Button color="transparent" onClick={() => handleClick('view')}>View</Button>
+                        <Button color="transparent" onClick={() => handleClick('delete')}>Delete</Button>
                       </div>
                     </CardBody>
                   </Card>
                 </Collapse>
-              </div>
             </Card>
           </Card>
         </Col>

--- a/src/components/DreamCard.js
+++ b/src/components/DreamCard.js
@@ -59,7 +59,8 @@ const DreamCard = ({
               <Row><div className="date">november 11, 2011</div></Row>
               <Row><div></div></Row>
               <div>
-                <Button color="transparent" onClick={toggle} style={{ marginBottom: '1rem' }}><i className="material-icons" id="expand-arrow"> keyboard_arrow_down </i></Button>
+                <Button color="transparent" onClick={toggle} style={{ marginBottom: '1rem' }}>
+                  <i className="material-icons" id="expand-arrow"> keyboard_arrow_down </i></Button>
                 <Collapse isOpen={isOpen}>
                   <Card>
                     <CardBody>
@@ -89,7 +90,6 @@ const DreamCard = ({
           </Card>
         </Col>
       </Row>
-
     </Container>
   );
 };

--- a/src/components/DreamCard.js
+++ b/src/components/DreamCard.js
@@ -65,7 +65,6 @@ const DreamCard = ({
                   <Card>
                     <CardBody>
                       <CardText>{entry}</CardText>
-                      <CardText>ADD TAGS HERE</CardText>
                       <div className="card-link-wrapper">
                       <Button color="transparent" onClick={() => handleClick('view')}>View</Button>
                       <Button color="transparent" onClick={() => handleClick('delete')}>Delete</Button>

--- a/src/components/DreamCard.js
+++ b/src/components/DreamCard.js
@@ -3,8 +3,13 @@ import { useHistory } from 'react-router-dom';
 import {
   Button,
   Card,
-  CardText,
-  CardTitle
+  CardTitle,
+  Container,
+  Row,
+  Col,
+  Collapse,
+  CardBody,
+  CardText
 } from 'reactstrap';
 import PropTypes from 'prop-types';
 import { deleteDream } from '../helpers/data/DreamData';
@@ -13,12 +18,14 @@ import DreamForm from './DreamForm';
 const DreamCard = ({
   firebaseKey,
   name,
-  grade,
-  teacher,
+  entry,
   setDreams
 }) => {
   const [editing, setEditing] = useState(false);
   const history = useHistory();
+  const [isOpen, setIsOpen] = useState(false);
+
+  const toggle = () => setIsOpen(!isOpen);
 
   const handleClick = (type) => {
     switch (type) {
@@ -38,34 +45,59 @@ const DreamCard = ({
   };
 
   return (
-    <Card body>
-      <CardTitle tag="h5">{name}</CardTitle>
-      <CardText>Grade: {grade}</CardText>
-      <CardText>Teacher: {teacher}</CardText>
-      <Button color="warning" onClick={() => handleClick('view')}>View Dream</Button>
-      <Button color="danger" onClick={() => handleClick('delete')}>Delete Dream</Button>
-      <Button color="info" onClick={() => handleClick('edit')}>
-        {editing ? 'Close Form' : 'Edit Dream'}
-      </Button>
-      {
-        editing && <DreamForm
-          formTitle='Edit Dream'
-          setDreams={setDreams}
-          firebaseKey={firebaseKey}
-          name={name}
-          grade={grade}
-          teacher={teacher}
-        />
-      }
-    </Card>
+    <Container className="card-container">
+      <Row>
+        <Col sm="12" md={{ size: 6, offset: 3 }}>
+          <Card className="card-grey">
+            <Card body className="card-white">
+              <Row><div className="top-text">
+                <CardTitle tag="h5">{name}</CardTitle>
+                <div><i className="material-icons dream-type-icon"> cloud </i></div>
+              </div>
+              </Row>
+              <Row><div>_______________________________________________</div></Row>
+              <Row><div className="date">november 11, 2011</div></Row>
+              <Row><div></div></Row>
+              <div>
+                <Button color="transparent" onClick={toggle} style={{ marginBottom: '1rem' }}><i className="material-icons" id="expand-arrow"> keyboard_arrow_down </i></Button>
+                <Collapse isOpen={isOpen}>
+                  <Card>
+                    <CardBody>
+                      <CardText>{entry}</CardText>
+                      <CardText>ADD TAGS HERE</CardText>
+                      <div className="card-link-wrapper">
+                      <Button color="transparent" onClick={() => handleClick('view')}>View</Button>
+                      <Button color="transparent" onClick={() => handleClick('delete')}>Delete</Button>
+                      <Button color="transparent" onClick={() => handleClick('edit')}>
+                        {editing ? 'Close Form' : 'Edit'}
+                      </Button>
+                      {
+                        editing && <DreamForm
+                          formTitle='Edit Dream'
+                          setDreams={setDreams}
+                          firebaseKey={firebaseKey}
+                          name={name}
+                          entry={entry}
+                        />
+                      }
+                      </div>
+                    </CardBody>
+                  </Card>
+                </Collapse>
+              </div>
+            </Card>
+          </Card>
+        </Col>
+      </Row>
+
+    </Container>
   );
 };
 
 DreamCard.propTypes = {
   firebaseKey: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
-  teacher: PropTypes.string.isRequired,
-  grade: PropTypes.number.isRequired,
+  entry: PropTypes.string.isRequired,
   setDreams: PropTypes.func
 };
 

--- a/src/components/DreamForm.js
+++ b/src/components/DreamForm.js
@@ -14,14 +14,12 @@ const DreamForm = ({
   formTitle,
   setDreams,
   name,
-  teacher,
-  grade,
+  entry,
   firebaseKey
 }) => {
   const [dream, setDream] = useState({
     name: name || '',
-    teacher: teacher || '',
-    grade: grade || 0,
+    entry: entry || '',
     firebaseKey: firebaseKey || null
   });
   const history = useHistory();
@@ -30,7 +28,7 @@ const DreamForm = ({
     setDream((prevState) => ({
       ...prevState,
       [e.target.name]:
-        e.target.name === 'grade' ? Number(e.target.value) : e.target.value,
+        e.target.name === e.target.value,
     }));
   };
 
@@ -46,8 +44,7 @@ const DreamForm = ({
 
       setDream({
         name: '',
-        teacher: '',
-        grade: 0,
+        entry: '',
         firebaseKey: null
       });
     }
@@ -70,25 +67,13 @@ const DreamForm = ({
         </FormGroup>
 
         <FormGroup>
-          <Label for="teacher">Teacher:</Label>
+          <Label for="entry">entry:</Label>
           <Input
-            name='teacher'
-            id='teacher'
-            value={dream.teacher}
+            name='entry'
+            id='entry'
+            value={dream.entry}
             type='text'
-            placeholder='Enter a Teacher Name'
-            onChange={handleInputChange}
-          />
-        </FormGroup>
-
-        <FormGroup>
-          <Label for="grade">Grade:</Label>
-          <Input
-            name='grade'
-            id='grade'
-            value={dream.grade}
-            type='number'
-            placeholder='Enter a Grade'
+            placeholder='Enter a entry Name'
             onChange={handleInputChange}
           />
         </FormGroup>
@@ -103,8 +88,7 @@ DreamForm.propTypes = {
   formTitle: PropTypes.string.isRequired,
   setDreams: PropTypes.func,
   name: PropTypes.string,
-  teacher: PropTypes.string,
-  grade: PropTypes.number,
+  entry: PropTypes.string,
   firebaseKey: PropTypes.string
 };
 

--- a/src/components/DreamForm.js
+++ b/src/components/DreamForm.js
@@ -27,8 +27,7 @@ const DreamForm = ({
   const handleInputChange = (e) => {
     setDream((prevState) => ({
       ...prevState,
-      [e.target.name]:
-        e.target.name === e.target.value,
+      [e.target.name]: e.target.value,
     }));
   };
 

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -30,7 +30,7 @@ const NavBar = ({ user }) => {
   return (
     <div>
       <Navbar color="light" light expand="md">
-        <Link className="navbar-brand" to="/">NavBar</Link>
+        <Link className="navbar-brand" to="/">Lucid</Link>
         <NavbarToggler onClick={toggle} />
         <Collapse isOpen={isOpen} navbar>
           <Nav className="ml-auto" navbar>

--- a/src/components/SingleDreamCard.js
+++ b/src/components/SingleDreamCard.js
@@ -1,17 +1,42 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {
+  Card,
+  CardTitle,
+  Container,
+  Row,
+  Col,
+  CardText
+} from 'reactstrap';
 
-export default function SingleDreamCard({ children, dream }) {
+export default function SingleDreamCard({ dream }) {
   return (
-    <div>
-      <h1>Dreams: {dream.name }</h1>
-        {children}
-      <footer>Footer</footer>
+    <div className="">
+      <Container className="card-container">
+      <Row>
+        <Col sm="12" md={{ size: 6, offset: 3 }}>
+          <Card className="card-grey">
+            <Card body className="card-white">
+              <Row><div className="top-text">
+                <CardTitle tag="h5">{ dream.name }</CardTitle>
+                <div><i className="material-icons dream-type-icon"> cloud </i></div>
+              </div>
+              </Row>
+              <Row><div>_______________________________________________</div></Row>
+              <Row><div className="date">november 11, 2011</div></Row>
+              <Row><CardText></CardText>{ dream.entry }</Row>
+              <Row><CardText></CardText></Row>
+              <Row><CardText></CardText></Row>
+              <Row><CardText></CardText></Row>
+            </Card>
+          </Card>
+        </Col>
+      </Row>
+    </Container>
     </div>
   );
 }
 
 SingleDreamCard.propTypes = {
-  children: PropTypes.any,
   dream: PropTypes.object
 };

--- a/src/components/SingleDreamCard.js
+++ b/src/components/SingleDreamCard.js
@@ -11,7 +11,7 @@ import {
 
 export default function SingleDreamCard({ dream }) {
   return (
-    <div className="">
+    <div className="single-dream-content">
       <Container className="card-container">
       <Row>
         <Col sm="12" md={{ size: 6, offset: 3 }}>

--- a/src/helpers/data/DreamData.js
+++ b/src/helpers/data/DreamData.js
@@ -27,7 +27,7 @@ const deleteDream = (firebaseKey) => new Promise((resolve, reject) => {
 });
 
 const updateDream = (dream) => new Promise((resolve, reject) => {
-  axios.patch(`${dbUrl}/dreams/${dream.firebaseKey}.json`, dream)
+  axios.put(`${dbUrl}/dreams/${dream.firebaseKey}.json`, dream)
     .then(() => getDreams().then(resolve))
     .catch((error) => reject(error));
 });

--- a/src/styles/_cards.scss
+++ b/src/styles/_cards.scss
@@ -1,13 +1,141 @@
-.card-container {
+// header {
+//   display: flex;
+//   flex-flow: column wrap;
+//   justify-content: center;
+//   border: 1px solid lightgrey;
+//   height: 5em;
+//   width: 34em;
+//   padding-top: 1em;
+//   padding-bottom: 1em;
+//   margin-top: 1em;
+//   margin-left: 0em;
+//   border-bottom: 0em;
+//   box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.1);
+// }
+
+// .header-icon-cloud-container {
+//   display: flex;
+//   justify-content: flex-start;
+// }
+
+// .header-top-text {
+//   display: flex;
+//   justify-content: center;
+// }
+
+// #header-cloud {
+//   margin-left: -5em;
+//   font-size: 2em;
+//   opacity: .9;
+//   transition: opacity 1s ease-in-out 1s;
+// }
+
+// #header-cloud:hover {
+//   color: darkorchid;
+//   opacity: 1;
+// }
+
+// .header-title {
+//   font-size: 30px;
+//   font-family: 'Sacramento', cursive;
+//   margin-left: 0em;
+//   font-weight: bolder;
+// }
+
+// .header-date {
+//   text-align: center;
+//   font-size: 10px;
+//   font-family: 'Almarai', sans-serif;
+//   margin-left: 0em;
+// }
+
+// .main-section-container {
+//   border: 1px solid lightgrey;
+//   padding-left: 2em;
+//   padding-right: 2em;
+//   padding-bottom: 3em;
+
+// }
+
+#add-button {
   display: flex;
-  flex-flow: row wrap;
+  justify-content: center;
+  font-size: 3em;
+  margin-top: .3em;
+  margin-bottom: .4em;
+  color: darkorchid;
+}
 
-  .card {
-    width: 300px;
-    margin: 5px;
-  }
+.card-grey {
+  display: flex;
+  flex-flow: column wrap;
+  align-items: center;
+  background-color: rgb(222, 222, 222);
+  width: 30em;
+  height: 10.8em;
+  box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
+  border-radius: 5px;
+  margin-bottom: 1em;
+}
 
-  .card-body {
-    flex: none;
-  }
+.card-white {
+  background-color: white;
+  height: 7em;
+  width: 28em;
+  margin: 1em;
+  box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
+  border-radius: 5px;
+}
+
+.top-text {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: 2em;
+  width: 28em;
+  margin-top: 1em;
+  margin-bottom: 0;
+}
+
+.dream-type {
+  margin-left: 1.5em;
+  font-size: 18px;
+  font-family: 'Almarai', sans-serif;
+
+}
+
+.dream-type-icon {
+  margin-right: 1.5em;
+  font-size: 1em;
+}
+
+// hr {
+//   width: 24em;
+// }
+
+.date {
+  margin-left: 3em;
+  font-family: 'Almarai', sans-serif;
+  font-size: .7em;
+}
+
+#expand-arrow {
+  font-size: 1.4em;
+  font-weight: bolder;
+}
+
+a {
+  color: black;
+  text-decoration: none;
+}
+
+.icons {
+  display: flex;
+  justify-content: space-around;
+  margin-top: 2.5em;
+}
+
+.card-link-wrapper {
+  display: flex;
+  justify-content: center;
 }

--- a/src/views/Dreams.js
+++ b/src/views/Dreams.js
@@ -11,8 +11,7 @@ function Dreams({ dreams, setDreams }) {
             key={dreamInfo.firebaseKey}
             firebaseKey={dreamInfo.firebaseKey}
             name={dreamInfo.name}
-            teacher={dreamInfo.teacher}
-            grade={Number(dreamInfo.grade)}
+            entry={dreamInfo.entry}
             setDreams={setDreams}
           />
         ))}

--- a/src/views/SingleDream.js
+++ b/src/views/SingleDream.js
@@ -16,8 +16,7 @@ export default function SingleDream() {
     <div>
       <SingleDreamCard dream={dream}>
         <h2>{dream.name}</h2>
-        <h3>{dream.teacher}</h3>
-        <h3>{dream.grade}</h3>
+        <h3>{dream.entry}</h3>
       </SingleDreamCard>
     </div>
   );

--- a/src/views/Welcome.js
+++ b/src/views/Welcome.js
@@ -5,7 +5,7 @@ export default function Welcome() {
     <div className="welcome-page">
       <div className="welcome-page-content">
           <div className="welcome-title"><h1>welcome</h1></div>
-          <div className="cloud-container"><a href="LOGIN/login.html"><i className="material-icons" id="cloud"> wb_cloud </i></a></div>
+          <div className="cloud-container"><a href="GO TO HOMEPAGE"><i className="material-icons" id="cloud"> wb_cloud </i></a></div>
       </div>
     </div>
   );


### PR DESCRIPTION
This PRcompletes the following issue tickets: 

#15 
#34 
#16
#37 
#16 
#36 

- [ ] Added Dream Cards
- [ ]  Styled dream card V1
- [ ]  Created Single Dream Card & Page
- [ ]  Styled Single Dream Card V1
- [ ]  Tweaked Nav Verbage
- [ ]  Added Dropdown menu on cards for edit, delete and view options
- [ ] BUG in edit FIXED

User can now view dream cards populated with data from Firebase
User can click on expand arrow to view menu
User can click on DELETE and card will delete off DOM and Delete Dynamically off Firebase
User can click on EDIT and menu will pop down
User is able to EDIT Dream card


Dynamic Dream Cards
<img width="1433" alt="Screen Shot 2021-06-02 at 11 29 53 PM" src="https://user-images.githubusercontent.com/68397076/120587140-71000880-c3fa-11eb-8b45-da3721d10d6c.png">

Expand Menu
<img width="534" alt="Screen Shot 2021-06-02 at 11 30 41 PM" src="https://user-images.githubusercontent.com/68397076/120587198-8e34d700-c3fa-11eb-86a3-c5de0aa5ccf1.png">

Dynamic Single Dream Card
<img width="1433" alt="Screen Shot 2021-06-02 at 11 31 39 PM" src="https://user-images.githubusercontent.com/68397076/120587285-b02e5980-c3fa-11eb-9442-956dd0735f7d.png">

V1 Edit Menu
<img width="696" alt="Screen Shot 2021-06-03 at 12 24 35 AM" src="https://user-images.githubusercontent.com/68397076/120591627-14a0e700-c402-11eb-9c33-8ff031ae94bb.png">
