### PR TITLE
Dream Card Popover Menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.15.3",
+    "@material-ui/core": "^4.11.4",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/styles": "^4.11.4",
     "@testing-library/jest-dom": "^5.11.4",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "@fortawesome/fontawesome-free": "^5.15.3",
     "@material-ui/core": "^5.0.0-alpha.35",
     "@material-ui/icons": "^4.11.2",
-    "@material-ui/lab": "^5.0.0-alpha.35",
     "@material-ui/styles": "^4.11.4",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -3,9 +3,12 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@emotion/react": "^11.4.0",
+    "@emotion/styled": "^11.3.0",
     "@fortawesome/fontawesome-free": "^5.15.3",
-    "@material-ui/core": "^4.11.4",
+    "@material-ui/core": "^5.0.0-alpha.35",
     "@material-ui/icons": "^4.11.2",
+    "@material-ui/lab": "^5.0.0-alpha.35",
     "@material-ui/styles": "^4.11.4",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",

--- a/src/components/DreamCard.js
+++ b/src/components/DreamCard.js
@@ -1,8 +1,19 @@
 import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
+import VisibilityIcon from '@material-ui/icons/Visibility';
+import EditIcon from '@material-ui/icons/Edit';
+import DeleteIcon from '@material-ui/icons/Delete';
+import Fab from '@material-ui/core/Fab';
 import {
-  Button, Card, CardTitle, Container, Row,
-  Col, Collapse, CardBody, CardText
+  Button,
+  Card,
+  CardTitle,
+  Container,
+  Row,
+  Col,
+  Collapse,
+  CardBody,
+  CardText,
 } from 'reactstrap';
 import PropTypes from 'prop-types';
 import { deleteDream } from '../helpers/data/DreamData';
@@ -54,36 +65,37 @@ const DreamCard = ({
               </Row>
 
               <Row><div>_______________________________________________</div></Row>
-
-              <div>
-                <Button color="transparent float-right" style={{ marginBottom: '1rem' }} onClick={() => handleClick('edit')}>
-                  {editing ? 'Done' : 'Edit'}
-                </Button>
-                {
-                  editing && <DreamForm
-                    formTitle='Edit Dream'
-                    setDreams={setDreams}
-                    firebaseKey={firebaseKey}
-                    name={name}
-                    entry={entry}
-                  />
-                }
-
-              </div>
             </Card>
+
             <Button color="transparent" onClick={toggle} style={{ marginBottom: '1rem' }}>
-                  <i className="material-icons" id="expand-arrow"> keyboard_arrow_down </i></Button>
-                <Collapse isOpen={isOpen}>
-                  <Card>
-                    <CardBody>
-                      <CardText>{entry}</CardText>
-                      <div className="card-link-wrapper">
-                        <Button color="transparent" onClick={() => handleClick('view')}>View</Button>
-                        <Button color="transparent" onClick={() => handleClick('delete')}>Delete</Button>
-                      </div>
-                    </CardBody>
-                  </Card>
-                </Collapse>
+              <i className="material-icons" id="expand-arrow"> keyboard_arrow_down </i></Button>
+            <Collapse isOpen={isOpen}>
+              <Card>
+                <CardBody>
+                  <CardText>{entry}</CardText>
+                  <div className="card-link-wrapper">
+                    <Button color="transparent" onClick={() => handleClick('view')}>
+                      <Fab disabled aria-label="visibility"><VisibilityIcon /></Fab>
+                    </Button>
+                    <Button color="transparent" onClick={() => handleClick('delete')}>
+                      <Fab disabled aria-label="delete"><DeleteIcon /></Fab>
+                    </Button>
+                    <Button color="transparent float-right" style={{ marginBottom: '1rem' }} onClick={() => handleClick('edit')}>
+                     <Fab disabled aria-label="edit"><EditIcon /></Fab>
+                    </Button>
+                    {
+                      editing && <DreamForm
+                        formTitle='Edit Dream'
+                        setDreams={setDreams}
+                        firebaseKey={firebaseKey}
+                        name={name}
+                        entry={entry}
+                      />
+                    }
+                  </div>
+                </CardBody>
+              </Card>
+            </Collapse>
           </Card>
 
         </Col>

--- a/src/components/DreamCard.js
+++ b/src/components/DreamCard.js
@@ -11,9 +11,10 @@ import {
   Container,
   Row,
   Col,
-  Collapse,
-  CardBody,
   CardText,
+  UncontrolledPopover,
+  PopoverHeader,
+  PopoverBody
 } from 'reactstrap';
 import PropTypes from 'prop-types';
 import { deleteDream } from '../helpers/data/DreamData';
@@ -26,10 +27,7 @@ const DreamCard = ({
   setDreams
 }) => {
   const [editing, setEditing] = useState(false);
-  const [isOpen, setIsOpen] = useState(false);
   const history = useHistory();
-
-  const toggle = () => setIsOpen(!isOpen);
 
   const handleClick = (type) => {
     switch (type) {
@@ -61,12 +59,17 @@ const DreamCard = ({
                 </div>
               </Row>
               <Row><div>_______________________________________________</div></Row>
+              <Row>
+                <CardText>november 11, 2011</CardText>
+              </Row>
             </Card>
-            <Button color="transparent" onClick={toggle} style={{ marginBottom: '1rem' }}>
-              <i className="material-icons" id="expand-arrow"> keyboard_arrow_down </i></Button>
-            <Collapse isOpen={isOpen}>
-              <Card>
-                <CardBody>
+            <div>
+              <Button id="PopoverFocus" type="button">
+                <i className="material-icons" id="expand-arrow"> keyboard_arrow_down </i>
+              </Button>
+              <UncontrolledPopover trigger="focus" placement="bottom" target="PopoverFocus">
+                <PopoverHeader>Title</PopoverHeader>
+                <PopoverBody>
                   <CardText>{entry}</CardText>
                   <div className="card-link-wrapper">
                     <Button color="transparent" onClick={() => handleClick('view')}>
@@ -88,13 +91,15 @@ const DreamCard = ({
                       />
                     }
                   </div>
-                </CardBody>
-              </Card>
-            </Collapse>
+                </PopoverBody>
+              </UncontrolledPopover>
+            </div>
           </Card>
         </Col>
       </Row>
+
     </Container>
+
   );
 };
 

--- a/src/components/DreamCard.js
+++ b/src/components/DreamCard.js
@@ -1,7 +1,5 @@
 import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import { makeStyles } from '@material-ui/core/styles';
-import TextField from '@material-ui/core/TextField';
 import {
   Button, Card, CardTitle, Container, Row,
   Col, Collapse, CardBody, CardText
@@ -9,18 +7,6 @@ import {
 import PropTypes from 'prop-types';
 import { deleteDream } from '../helpers/data/DreamData';
 import DreamForm from './DreamForm';
-
-const useStyles = makeStyles((theme) => ({
-  container: {
-    display: 'flex',
-    flexWrap: 'wrap',
-  },
-  textField: {
-    marginLeft: theme.spacing(1),
-    marginRight: theme.spacing(1),
-    width: 200,
-  },
-}));
 
 const DreamCard = ({
   firebaseKey,
@@ -31,7 +17,6 @@ const DreamCard = ({
   const [editing, setEditing] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
   const history = useHistory();
-  const classes = useStyles();
 
   const toggle = () => setIsOpen(!isOpen);
 
@@ -56,28 +41,20 @@ const DreamCard = ({
     <Container className="card-container">
       <Row>
         <Col sm="12" md={{ size: 6, offset: 3 }}>
+
           <Card className="card-grey">
+
             <Card body className="card-white">
+
               <Row>
                 <div className="top-text">
-                <CardTitle tag="h5">{name}</CardTitle>
-                <div><i className="material-icons dream-type-icon"> cloud </i></div>
+                  <CardTitle tag="h5">{name}</CardTitle>
+                  <div><i className="material-icons dream-type-icon"> cloud </i></div>
                 </div>
               </Row>
+
               <Row><div>_______________________________________________</div></Row>
-              <Row>
-                <div className="date">
-                  <form className={classes.container} noValidate>
-                    <TextField
-                      id="date"
-                      type="date"
-                      defaultValue="2017-05-24"
-                      className={classes.textField}
-                      InputLabelProps={{
-                        shrink: true,
-                      }}
-                    />
-                  </form></div></Row>
+
               <div>
                 <Button color="transparent float-right" style={{ marginBottom: '1rem' }} onClick={() => handleClick('edit')}>
                   {editing ? 'Done' : 'Edit'}
@@ -91,7 +68,10 @@ const DreamCard = ({
                     entry={entry}
                   />
                 }
-                <Button color="transparent" onClick={toggle} style={{ marginBottom: '1rem' }}>
+
+              </div>
+            </Card>
+            <Button color="transparent" onClick={toggle} style={{ marginBottom: '1rem' }}>
                   <i className="material-icons" id="expand-arrow"> keyboard_arrow_down </i></Button>
                 <Collapse isOpen={isOpen}>
                   <Card>
@@ -104,9 +84,8 @@ const DreamCard = ({
                     </CardBody>
                   </Card>
                 </Collapse>
-              </div>
-            </Card>
           </Card>
+
         </Col>
       </Row>
     </Container>

--- a/src/components/DreamCard.js
+++ b/src/components/DreamCard.js
@@ -64,15 +64,14 @@ const DreamCard = ({
               </Row>
             </Card>
             <div>
-              <Button id="PopoverFocus" type="button">
+              <Button id="PopoverClick" type="button">
                 <i className="material-icons" id="expand-arrow"> keyboard_arrow_down </i>
               </Button>
-              <UncontrolledPopover trigger="focus" placement="bottom" target="PopoverFocus">
+              <UncontrolledPopover trigger="click" placement="bottom" target="PopoverClick">
                 <PopoverHeader>Title</PopoverHeader>
                 <PopoverBody>
-                  <CardText>{entry}</CardText>
                   <div className="card-link-wrapper">
-                    <Button color="transparent" onClick={() => handleClick('view')}>
+                  <Button color="transparent" onClick={() => handleClick('view')}>
                       <Fab disabled aria-label="visibility"><VisibilityIcon /></Fab>
                     </Button>
                     <Button color="transparent" onClick={() => handleClick('delete')}>

--- a/src/components/DreamCard.js
+++ b/src/components/DreamCard.js
@@ -52,21 +52,16 @@ const DreamCard = ({
     <Container className="card-container">
       <Row>
         <Col sm="12" md={{ size: 6, offset: 3 }}>
-
           <Card className="card-grey">
-
             <Card body className="card-white">
-
               <Row>
                 <div className="top-text">
                   <CardTitle tag="h5">{name}</CardTitle>
                   <div><i className="material-icons dream-type-icon"> cloud </i></div>
                 </div>
               </Row>
-
               <Row><div>_______________________________________________</div></Row>
             </Card>
-
             <Button color="transparent" onClick={toggle} style={{ marginBottom: '1rem' }}>
               <i className="material-icons" id="expand-arrow"> keyboard_arrow_down </i></Button>
             <Collapse isOpen={isOpen}>
@@ -80,8 +75,8 @@ const DreamCard = ({
                     <Button color="transparent" onClick={() => handleClick('delete')}>
                       <Fab disabled aria-label="delete"><DeleteIcon /></Fab>
                     </Button>
-                    <Button color="transparent float-right" style={{ marginBottom: '1rem' }} onClick={() => handleClick('edit')}>
-                     <Fab disabled aria-label="edit"><EditIcon /></Fab>
+                    <Button color="transparent" style={{ marginBottom: '1rem' }} onClick={() => handleClick('edit')}>
+                      <Fab disabled aria-label="edit"><EditIcon /></Fab>
                     </Button>
                     {
                       editing && <DreamForm
@@ -97,7 +92,6 @@ const DreamCard = ({
               </Card>
             </Collapse>
           </Card>
-
         </Col>
       </Row>
     </Container>

--- a/src/components/DreamCard.js
+++ b/src/components/DreamCard.js
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
+import { makeStyles } from '@material-ui/core/styles';
+import TextField from '@material-ui/core/TextField';
 import {
   Button, Card, CardTitle, Container, Row,
   Col, Collapse, CardBody, CardText
@@ -7,6 +9,18 @@ import {
 import PropTypes from 'prop-types';
 import { deleteDream } from '../helpers/data/DreamData';
 import DreamForm from './DreamForm';
+
+const useStyles = makeStyles((theme) => ({
+  container: {
+    display: 'flex',
+    flexWrap: 'wrap',
+  },
+  textField: {
+    marginLeft: theme.spacing(1),
+    marginRight: theme.spacing(1),
+    width: 200,
+  },
+}));
 
 const DreamCard = ({
   firebaseKey,
@@ -17,6 +31,7 @@ const DreamCard = ({
   const [editing, setEditing] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
   const history = useHistory();
+  const classes = useStyles();
 
   const toggle = () => setIsOpen(!isOpen);
 
@@ -43,15 +58,28 @@ const DreamCard = ({
         <Col sm="12" md={{ size: 6, offset: 3 }}>
           <Card className="card-grey">
             <Card body className="card-white">
-              <Row><div className="top-text">
+              <Row>
+                <div className="top-text">
                 <CardTitle tag="h5">{name}</CardTitle>
                 <div><i className="material-icons dream-type-icon"> cloud </i></div>
-              </div>
+                </div>
               </Row>
               <Row><div>_______________________________________________</div></Row>
-              <Row><div className="date">november 11, 2011</div></Row>
+              <Row>
+                <div className="date">
+                  <form className={classes.container} noValidate>
+                    <TextField
+                      id="date"
+                      type="date"
+                      defaultValue="2017-05-24"
+                      className={classes.textField}
+                      InputLabelProps={{
+                        shrink: true,
+                      }}
+                    />
+                  </form></div></Row>
               <div>
-                <Button color="transparent" style={{ marginBottom: '1rem' }} onClick={() => handleClick('edit')}>
+                <Button color="transparent float-right" style={{ marginBottom: '1rem' }} onClick={() => handleClick('edit')}>
                   {editing ? 'Done' : 'Edit'}
                 </Button>
                 {
@@ -63,7 +91,6 @@ const DreamCard = ({
                     entry={entry}
                   />
                 }
-                           </div>
                 <Button color="transparent" onClick={toggle} style={{ marginBottom: '1rem' }}>
                   <i className="material-icons" id="expand-arrow"> keyboard_arrow_down </i></Button>
                 <Collapse isOpen={isOpen}>
@@ -77,6 +104,7 @@ const DreamCard = ({
                     </CardBody>
                   </Card>
                 </Collapse>
+              </div>
             </Card>
           </Card>
         </Col>

--- a/src/components/DreamForm.js
+++ b/src/components/DreamForm.js
@@ -15,11 +15,13 @@ const DreamForm = ({
   setDreams,
   name,
   entry,
+  date,
   firebaseKey
 }) => {
   const [dream, setDream] = useState({
     name: name || '',
     entry: entry || '',
+    date: date || '',
     firebaseKey: firebaseKey || null
   });
   const history = useHistory();
@@ -44,6 +46,7 @@ const DreamForm = ({
       setDream({
         name: '',
         entry: '',
+        date: '',
         firebaseKey: null
       });
     }
@@ -54,7 +57,7 @@ const DreamForm = ({
       <Form id='addDreamForm' autoComplete='off' onSubmit={handleSubmit}>
         <h2>{formTitle}</h2>
         <FormGroup>
-          <Label for="name">Name:</Label>
+          <Label for="name"></Label>
           <Input
             name='name'
             id='name'
@@ -66,13 +69,25 @@ const DreamForm = ({
         </FormGroup>
 
         <FormGroup>
-          <Label for="entry">entry:</Label>
+          <Label for="entry"></Label>
           <Input
             name='entry'
             id='entry'
             value={dream.entry}
             type='text'
             placeholder='Enter a entry Name'
+            onChange={handleInputChange}
+          />
+        </FormGroup>
+
+        <FormGroup>
+          <Label for="date"></Label>
+          <Input
+            name='date'
+            id='date'
+            value={dream.date}
+            type='text'
+            placeholder='Enter a dream date'
             onChange={handleInputChange}
           />
         </FormGroup>
@@ -88,6 +103,7 @@ DreamForm.propTypes = {
   setDreams: PropTypes.func,
   name: PropTypes.string,
   entry: PropTypes.string,
+  date: PropTypes.string,
   firebaseKey: PropTypes.string
 };
 

--- a/src/styles/_cards.scss
+++ b/src/styles/_cards.scss
@@ -72,7 +72,7 @@
   align-items: center;
   background-color: rgb(222, 222, 222);
   width: 30em;
-  height: 10.8em;
+  height: 13em;
   box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
   border-radius: 5px;
   margin-bottom: 1em;

--- a/src/styles/_dreamCards.scss
+++ b/src/styles/_dreamCards.scss
@@ -72,7 +72,7 @@
   align-items: center;
   background-color: rgb(222, 222, 222);
   width: 30em;
-  height: 13em;
+  height: 14em;
   box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
   border-radius: 5px;
   margin-bottom: 1em;
@@ -80,7 +80,7 @@
 
 .card-white {
   background-color: white;
-  height: 7em;
+  height: 7.5em;
   width: 28em;
   margin: 1em;
   box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
@@ -122,6 +122,11 @@
 #expand-arrow {
   font-size: 1.4em;
   font-weight: bolder;
+}
+
+.expand-arrow-btn {
+  width: 10px;
+  height: 10px;
 }
 
 a {

--- a/src/styles/_forms.scss
+++ b/src/styles/_forms.scss
@@ -1,8 +1,8 @@
 .dream-form {
   margin: auto;
   padding-top: 50px;
+}
 
-  h2 {
-    text-align: center;
-  }
+h2 {
+  text-align: center;
 }

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,5 +1,5 @@
 @import "~@fortawesome/fontawesome-free/css/all.min.css";
 @import 'variables';
-@import 'cards';
+@import 'dreamCards';
 @import 'forms';
 @import 'welcome';

--- a/src/views/HomePage.js
+++ b/src/views/HomePage.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function HomePage() {
+  return (
+    <div>
+      <h1>homepage</h1>
+    </div>
+  );
+}

--- a/src/views/Welcome.js
+++ b/src/views/Welcome.js
@@ -5,7 +5,7 @@ export default function Welcome() {
     <div className="welcome-page">
       <div className="welcome-page-content">
           <div className="welcome-title"><h1>welcome</h1></div>
-          <div className="cloud-container"><a href="GO TO HOMEPAGE"><i className="material-icons" id="cloud"> wb_cloud </i></a></div>
+          <div className="cloud-container"><a href="./HomePage.js"><i className="material-icons" id="cloud"> wb_cloud </i></a></div>
       </div>
     </div>
   );


### PR DESCRIPTION
This PR enhances or solves the following issue tickets:

#15 
#36 

User is now able to see an updated version of a dropdown menu
User can choose between a set of icons to view, edit and delete card
 
Dream Card V2
<img width="499" alt="Screen Shot 2021-06-03 at 11 03 39 AM" src="https://user-images.githubusercontent.com/68397076/120676122-5b6efb00-c45b-11eb-8dff-65026267677e.png">

Dream Card Popover V2
<img width="491" alt="Screen Shot 2021-06-03 at 11 04 19 AM" src="https://user-images.githubusercontent.com/68397076/120676259-73467f00-c45b-11eb-93ea-9bb0319d3d05.png">

