### PR TITLE
Create Dream Cards Functional

### DIFF
--- a/src/components/DreamCard.js
+++ b/src/components/DreamCard.js
@@ -24,6 +24,7 @@ const DreamCard = ({
   firebaseKey,
   name,
   entry,
+  logDate,
   setDreams
 }) => {
   const [editing, setEditing] = useState(false);
@@ -51,49 +52,51 @@ const DreamCard = ({
       <Row>
         <Col sm="12" md={{ size: 6, offset: 3 }}>
           <Card className="card-grey">
-            <Card body className="card-white">
+            <Card className="card-white">
               <Row>
                 <div className="top-text">
-                  <CardTitle tag="h5">{name}</CardTitle>
+                  <CardTitle>{name}</CardTitle>
                   <div><i className="material-icons dream-type-icon"> cloud </i></div>
                 </div>
               </Row>
-              <Row><div>_______________________________________________</div></Row>
+              <Row><div className="hr">___________________________________________________</div></Row>
               <Row>
-                <CardText>november 11, 2011</CardText>
+                <CardText>{logDate}</CardText>
               </Row>
             </Card>
             <div>
-              <Button id="PopoverClick" type="button">
+              <Button color="transparent" id="PopoverClick" type="button">
                 <i className="material-icons" id="expand-arrow"> keyboard_arrow_down </i>
               </Button>
               <UncontrolledPopover trigger="click" placement="bottom" target="PopoverClick">
                 <PopoverHeader>Title</PopoverHeader>
                 <PopoverBody>
                   <div className="card-link-wrapper">
-                  <Button color="transparent" onClick={() => handleClick('view')}>
+                    <Button color="transparent" onClick={() => handleClick('view')}>
                       <Fab disabled aria-label="visibility"><VisibilityIcon /></Fab>
+                    </Button>
+
+                    <Button color="transparent" onClick={() => handleClick('edit')}>
+                      <Fab disabled aria-label="edit"><EditIcon /></Fab>
                     </Button>
                     <Button color="transparent" onClick={() => handleClick('delete')}>
                       <Fab disabled aria-label="delete"><DeleteIcon /></Fab>
                     </Button>
-                    <Button color="transparent" style={{ marginBottom: '1rem' }} onClick={() => handleClick('edit')}>
-                      <Fab disabled aria-label="edit"><EditIcon /></Fab>
-                    </Button>
-                    {
-                      editing && <DreamForm
-                        formTitle='Edit Dream'
-                        setDreams={setDreams}
-                        firebaseKey={firebaseKey}
-                        name={name}
-                        entry={entry}
-                      />
-                    }
                   </div>
                 </PopoverBody>
               </UncontrolledPopover>
             </div>
           </Card>
+          {
+            editing && <DreamForm
+              formTitle='Edit Dream'
+              setDreams={setDreams}
+              firebaseKey={firebaseKey}
+              name={name}
+              entry={entry}
+              logDate={logDate}
+            />
+          }
         </Col>
       </Row>
 
@@ -106,6 +109,7 @@ DreamCard.propTypes = {
   firebaseKey: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   entry: PropTypes.string.isRequired,
+  logDate: PropTypes.any.isRequired,
   setDreams: PropTypes.func
 };
 

--- a/src/components/DreamForm.js
+++ b/src/components/DreamForm.js
@@ -15,13 +15,13 @@ const DreamForm = ({
   setDreams,
   name,
   entry,
-  date,
+  logDate,
   firebaseKey
 }) => {
   const [dream, setDream] = useState({
     name: name || '',
     entry: entry || '',
-    date: date || '',
+    logDate: logDate || '',
     firebaseKey: firebaseKey || null
   });
   const history = useHistory();
@@ -46,7 +46,7 @@ const DreamForm = ({
       setDream({
         name: '',
         entry: '',
-        date: '',
+        logDate: '',
         firebaseKey: null
       });
     }
@@ -81,11 +81,11 @@ const DreamForm = ({
         </FormGroup>
 
         <FormGroup>
-          <Label for="date"></Label>
+          <Label for="logDate"></Label>
           <Input
-            name='date'
-            id='date'
-            value={dream.date}
+            name='logDate'
+            id='logDate'
+            value={dream.logDate}
             type='text'
             placeholder='Enter a dream date'
             onChange={handleInputChange}
@@ -103,7 +103,7 @@ DreamForm.propTypes = {
   setDreams: PropTypes.func,
   name: PropTypes.string,
   entry: PropTypes.string,
-  date: PropTypes.string,
+  logDate: PropTypes.string,
   firebaseKey: PropTypes.string
 };
 

--- a/src/components/SingleDreamCard.js
+++ b/src/components/SingleDreamCard.js
@@ -23,7 +23,7 @@ export default function SingleDreamCard({ dream }) {
               </div>
               </Row>
               <Row><div>_______________________________________________</div></Row>
-              <Row><div className="date">november 11, 2011</div></Row>
+              <Row><div className="logDate">{dream.logDate}</div></Row>
               <Row><CardText></CardText>{ dream.entry }</Row>
               <Row><CardText></CardText></Row>
               <Row><CardText></CardText></Row>

--- a/src/helpers/Routes.js
+++ b/src/helpers/Routes.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Route, Switch } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import addDream from '../views/AddDream';
+import AddDream from '../views/AddDream';
 import Welcome from '../views/Welcome';
 import Dreams from '../views/Dreams';
 import SingleDream from '../views/SingleDream';
@@ -23,7 +23,7 @@ export default function Routes({ dreams, setDreams }) {
         />
         <Route
           path='/add-dream'
-          component={() => <addDream setDreams={setDreams} />}
+          component={() => <AddDream setDreams={setDreams} />}
         />
         <Route path='*' component={NotFound} />
       </Switch>

--- a/src/styles/_dreamCards.scss
+++ b/src/styles/_dreamCards.scss
@@ -71,7 +71,7 @@
   flex-flow: column wrap;
   align-items: center;
   background-color: rgb(222, 222, 222);
-  width: 30em;
+  width: 35em;
   height: 14em;
   box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
   border-radius: 5px;
@@ -79,10 +79,14 @@
 }
 
 .card-white {
+  display: flex;
+  justify-content: flex-start;
   background-color: white;
-  height: 7.5em;
-  width: 28em;
-  margin: 1em;
+  height: 10em;
+  width: 32em;
+  margin-top: 1em;
+  padding-top: 2em;
+  padding-left: 3em;
   box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
   border-radius: 5px;
 }
@@ -90,11 +94,8 @@
 .top-text {
   display: flex;
   justify-content: space-between;
-  align-items: center;
   height: 2em;
   width: 28em;
-  margin-top: 1em;
-  margin-bottom: 0;
 }
 
 .dream-type {
@@ -106,12 +107,15 @@
 
 .dream-type-icon {
   margin-right: 1.5em;
-  font-size: 1em;
+  font-size: 2em;
 }
 
-// hr {
-//   width: 24em;
-// }
+.hr {
+  text-align: center;
+  margin-top: -1em;
+  margin-right: 1em;
+  font-weight: lighter;
+}
 
 .date {
   margin-left: 3em;
@@ -124,9 +128,9 @@
   font-weight: bolder;
 }
 
-.expand-arrow-btn {
-  width: 10px;
-  height: 10px;
+.PopoverClick {
+  width: 1em;
+  height: 1em;
 }
 
 a {

--- a/src/views/AddDream.js
+++ b/src/views/AddDream.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import DreamForm from '../components/DreamForm';
 
-function addDream({ setDreams }) {
+function AddDream({ setDreams }) {
   return (
     <div>
       <DreamForm
@@ -13,8 +13,8 @@ function addDream({ setDreams }) {
   );
 }
 
-addDream.propTypes = {
+AddDream.propTypes = {
   setDreams: PropTypes.func.isRequired
 };
 
-export default addDream;
+export default AddDream;


### PR DESCRIPTION
This PR enhances or improves the following issue tickets:

#35 
#15 
#42 
#36 

User can now click Add Card tab where they can add info into an input form
V1 Input form stores info and adds another card to the dream card history page
Needs Styling in V2 push

Add Dream Card Form V1
<img width="1435" alt="Screen Shot 2021-06-03 at 12 07 58 PM" src="https://user-images.githubusercontent.com/68397076/120684480-58c4d380-c464-11eb-866f-c752a82c096f.png">

New Dream Card Added
<img width="828" alt="Screen Shot 2021-06-03 at 12 08 57 PM" src="https://user-images.githubusercontent.com/68397076/120684585-7abe5600-c464-11eb-9885-175c25d2f219.png">
