### PR TITLE
Add Dream Form Logic

### DIFF
--- a/src/components/DreamCard.js
+++ b/src/components/DreamCard.js
@@ -24,7 +24,7 @@ const DreamCard = ({
   firebaseKey,
   name,
   entry,
-  logDate,
+  date,
   setDreams
 }) => {
   const [editing, setEditing] = useState(false);
@@ -61,7 +61,7 @@ const DreamCard = ({
               </Row>
               <Row><div className="hr">___________________________________________________</div></Row>
               <Row>
-                <CardText>{logDate}</CardText>
+                <CardText className="date">{date} fix date</CardText>
               </Row>
             </Card>
             <div>
@@ -69,7 +69,7 @@ const DreamCard = ({
                 <i className="material-icons" id="expand-arrow"> keyboard_arrow_down </i>
               </Button>
               <UncontrolledPopover trigger="click" placement="bottom" target="PopoverClick">
-                <PopoverHeader>Title</PopoverHeader>
+                <PopoverHeader>{name}</PopoverHeader>
                 <PopoverBody>
                   <div className="card-link-wrapper">
                     <Button color="transparent" onClick={() => handleClick('view')}>
@@ -94,7 +94,7 @@ const DreamCard = ({
               firebaseKey={firebaseKey}
               name={name}
               entry={entry}
-              logDate={logDate}
+              date={date}
             />
           }
         </Col>
@@ -109,7 +109,7 @@ DreamCard.propTypes = {
   firebaseKey: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   entry: PropTypes.string.isRequired,
-  logDate: PropTypes.any.isRequired,
+  date: PropTypes.string,
   setDreams: PropTypes.func
 };
 

--- a/src/components/DreamForm.js
+++ b/src/components/DreamForm.js
@@ -5,7 +5,7 @@ import {
   Form,
   FormGroup,
   Label,
-  Input
+  Input,
 } from 'reactstrap';
 import PropTypes from 'prop-types';
 import { addDream, updateDream } from '../helpers/data/DreamData';
@@ -15,13 +15,13 @@ const DreamForm = ({
   setDreams,
   name,
   entry,
-  logDate,
+  date,
   firebaseKey
 }) => {
   const [dream, setDream] = useState({
     name: name || '',
     entry: entry || '',
-    logDate: logDate || '',
+    date: date || '',
     firebaseKey: firebaseKey || null
   });
   const history = useHistory();
@@ -30,6 +30,7 @@ const DreamForm = ({
     setDream((prevState) => ({
       ...prevState,
       [e.target.name]: e.target.value,
+      firebaseKey: ''
     }));
   };
 
@@ -46,7 +47,7 @@ const DreamForm = ({
       setDream({
         name: '',
         entry: '',
-        logDate: '',
+        date: '',
         firebaseKey: null
       });
     }
@@ -81,11 +82,11 @@ const DreamForm = ({
         </FormGroup>
 
         <FormGroup>
-          <Label for="logDate"></Label>
+          <Label for="date"></Label>
           <Input
-            name='logDate'
-            id='logDate'
-            value={dream.logDate}
+            name='date'
+            id='date'
+            value={dream.date}
             type='text'
             placeholder='Enter a dream date'
             onChange={handleInputChange}
@@ -103,7 +104,7 @@ DreamForm.propTypes = {
   setDreams: PropTypes.func,
   name: PropTypes.string,
   entry: PropTypes.string,
-  logDate: PropTypes.string,
+  date: PropTypes.string,
   firebaseKey: PropTypes.string
 };
 

--- a/src/components/DreamForm.js
+++ b/src/components/DreamForm.js
@@ -1,11 +1,9 @@
 import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import {
-  Button,
-  Form,
-  FormGroup,
-  Label,
-  Input,
+  Button, Form, FormGroup, Label,
+  Input, Card, CardHeader, Container,
+  CardFooter, CardBody, CardTitle,
 } from 'reactstrap';
 import PropTypes from 'prop-types';
 import { addDream, updateDream } from '../helpers/data/DreamData';
@@ -54,48 +52,54 @@ const DreamForm = ({
   };
 
   return (
-    <div className='dream-form'>
-      <Form id='addDreamForm' autoComplete='off' onSubmit={handleSubmit}>
-        <h2>{formTitle}</h2>
-        <FormGroup>
-          <Label for="name"></Label>
-          <Input
-            name='name'
-            id='name'
-            value={dream.name}
-            type='text'
-            placeholder='Enter a dream Name'
-            onChange={handleInputChange}
-          />
-        </FormGroup>
+    <Container className="dream-form-container">
+      <Card className="add-dream-card">
+        <CardHeader><h2>{formTitle}</h2></CardHeader>
+        <CardBody className="add-dream-card-body">
+          <CardTitle tag="h5">Special Title Treatment</CardTitle>
+          <Form id='add-dream-form' autoComplete='off' onSubmit={handleSubmit}>
+          <FormGroup>
+            <Label for="name"></Label>
+            <Input
+              name='name'
+              id='name'
+              value={dream.name}
+              type='text'
+              placeholder='Enter Dream Title'
+              onChange={handleInputChange}
+            />
+          </FormGroup>
 
-        <FormGroup>
-          <Label for="entry"></Label>
-          <Input
-            name='entry'
-            id='entry'
-            value={dream.entry}
-            type='text'
-            placeholder='Enter a entry Name'
-            onChange={handleInputChange}
-          />
-        </FormGroup>
+          <FormGroup>
+            <Label for="entry"></Label>
+            <Input
+              name='entry'
+              id='entry'
+              value={dream.entry}
+              type='text'
+              placeholder='Dream Description'
+              onChange={handleInputChange}
+            />
+          </FormGroup>
 
-        <FormGroup>
-          <Label for="date"></Label>
-          <Input
-            name='date'
-            id='date'
-            value={dream.date}
-            type='text'
-            placeholder='Enter a dream date'
-            onChange={handleInputChange}
-          />
-        </FormGroup>
+          <FormGroup>
+            <Label for="date"></Label>
+            <Input
+              name='date'
+              id='date'
+              value={dream.date}
+              type='text'
+              placeholder='Enter Dream Date'
+              onChange={handleInputChange}
+            />
+          </FormGroup>
 
-        <Button type='submit'>Submit</Button>
-      </Form>
-    </div>
+          <Button className="add-btn-submit float-right" type='submit'>Submit</Button>
+        </Form>
+        </CardBody>
+        <CardFooter>Footer</CardFooter>
+      </Card>
+    </Container>
   );
 };
 

--- a/src/components/SingleDreamCard.js
+++ b/src/components/SingleDreamCard.js
@@ -23,7 +23,7 @@ export default function SingleDreamCard({ dream }) {
               </div>
               </Row>
               <Row><div>_______________________________________________</div></Row>
-              <Row><div className="logDate">{dream.logDate}</div></Row>
+              <Row><div className="date">{dream.date}</div></Row>
               <Row><CardText></CardText>{ dream.entry }</Row>
               <Row><CardText></CardText></Row>
               <Row><CardText></CardText></Row>

--- a/src/styles/_dreamCards.scss
+++ b/src/styles/_dreamCards.scss
@@ -118,9 +118,8 @@
 }
 
 .date {
-  margin-left: 3em;
   font-family: 'Almarai', sans-serif;
-  font-size: .7em;
+  font-size: .8em;
 }
 
 #expand-arrow {

--- a/src/styles/_forms.scss
+++ b/src/styles/_forms.scss
@@ -1,8 +1,18 @@
-.dream-form {
-  margin: auto;
-  padding-top: 50px;
+.dream-form-container {
+  display: flex; 
+  justify-content: center;
 }
 
 h2 {
   text-align: center;
+}
+
+.add-dream-card {
+  width: 40em;
+}
+
+.add-dream-card-body {
+  display: flex; 
+  justify-content: center;
+  flex-direction: column;
 }

--- a/src/views/Dreams.js
+++ b/src/views/Dreams.js
@@ -1,10 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import { Container } from 'reactstrap';
 import DreamCard from '../components/DreamCard';
 
 function Dreams({ dreams, setDreams }) {
   return (
-    <>
+    <Container className="">
+      <Link className="nav-link" to="/add-dream"><i className="material-icons" id="add-button"> add_circle </i></Link>
       <div className="card-container">
         {dreams.map((dreamInfo) => (
           <DreamCard
@@ -16,7 +19,7 @@ function Dreams({ dreams, setDreams }) {
           />
         ))}
       </div>
-    </>
+    </Container>
   );
 }
 


### PR DESCRIPTION
This PR updates and enhances the CREATE issue ticket that includes the add dream form

#44 
#15 
#17 

User is now able to log into the app
User can now see previous v2 dreams logged
User can now click a v2 add icon to add a dream
Once add icon is clicked user can fill out a v2 add dream form
When submitted user can now see dream added to history of dreams

Dream History View (Homepage) with ADD ICON V2
<img width="696" alt="Screen Shot 2021-06-03 at 3 44 44 PM" src="https://user-images.githubusercontent.com/68397076/120709576-9fc1c180-c482-11eb-82d9-57156ec93fde.png">

Add Dream Form V2
<img width="694" alt="Screen Shot 2021-06-03 at 3 45 23 PM" src="https://user-images.githubusercontent.com/68397076/120709646-b700af00-c482-11eb-834e-fc38c7074434.png">
